### PR TITLE
Fixed broken binding once for attributes.

### DIFF
--- a/src/directives/bind-attr-once/bind-attr-once.js
+++ b/src/directives/bind-attr-once/bind-attr-once.js
@@ -2,23 +2,23 @@
 
 /*
  * Binds the attributes to the expression once at startup,
- * Usage: <span fast-bind-attr-once="{attr1: myExpression, attr2: myOtherExpression}"></span>
+ * Usage: <tag fast-bind-attr-once="{attr1: 'myExpression', attr2: 'myOtherExpression'}"></tag>
+ *
+ * Real example:
+ * e.g. we have this data: obj={url: 'http://google.com', urlTitle: 'Go Search'}
+ * <a fast-bind-attr-once="{href: '{{obj.url}}', title: '{{obj.urlTitle}}'}"
  */
-
 
 angular.module('fastBind.bindAttrOnce', []).
   directive('fastBindAttrOnce', ['$parse', function($parse) {
     return {
-      compile: function compile(element, attributes) {
-        var expr = $parse(attributes.fastBindAttrOnce);
-
-        return function link(scope, element, attrs) {
-          var values = expr(scope);
-
-          angular.forEach(values, function(value, key) {
-            attributes.$set(key, value);
-          });
-        };
+      link: function (scope, element, attrs) {
+        var expr = $parse(attrs.fastBindAttrOnce);
+        var values = expr(scope);
+        
+        angular.forEach(values, function (value, key) {
+            attrs.$set(key, value);
+        });
       }
     };
   }]);


### PR DESCRIPTION
Previous version didn't work with {{}} expressions and didn't work correctly with latest Angular version.
This version:
- Binds attributes correctly.
- Works with {{}} markup.

If I have more spare time on work, I will write tests for this directive.
